### PR TITLE
add joint regularization term and update

### DIFF
--- a/src/adam/casadi/inverse_kinematics.py
+++ b/src/adam/casadi/inverse_kinematics.py
@@ -460,6 +460,15 @@ class InverseKinematics:
         else:
             raise ValueError("Unsupported target type")
 
+    def add_joint_regularization(self, weight: float = 1e-3):
+        """Add a regularization term to the cost function to minimize joint movement.
+
+        Args:
+            weight (float): Weight for the regularization term.
+        """
+        self.joint_position_target = self.opti.parameter(self.ndof)
+        self.cost_terms.append(weight * cs.sumsqr(self.joint_pos - self.joint_position_target))
+
     def update_target_position(self, frame: str, position: np.ndarray):
         """Update the target position for a frame.
 
@@ -521,6 +530,22 @@ class InverseKinematics:
             self.update_target_pose(frame, *target)  # type: ignore[arg-type]
         else:
             raise RuntimeError("Unknown target type")
+
+    def update_joint_regularization(self, joint_values: np.ndarray):
+        """Update the joint regularization target.
+
+        Args:
+            joint_values (np.ndarray): The new joint values to regularize towards.
+        """
+        if not hasattr(self, "joint_position_target"):
+            raise RuntimeError(
+                "Joint regularization has not been added. Call add_joint_regularization() first."
+            )
+        if joint_values is None:
+            joint_values = np.zeros(self.ndof) if self._cached_sol is None else self._cached_sol.value(self.joint_pos)
+            self.opti.set_value(self.joint_position_target, joint_values)
+        else:
+            self.opti.set_value(self.joint_position_target, joint_values)
 
     def set_initial_guess(self, base_transform: np.ndarray, joint_values: np.ndarray):
         """Set the initial guess for the optimization problem.

--- a/src/adam/casadi/inverse_kinematics.py
+++ b/src/adam/casadi/inverse_kinematics.py
@@ -467,7 +467,9 @@ class InverseKinematics:
             weight (float): Weight for the regularization term.
         """
         self.joint_position_target = self.opti.parameter(self.ndof)
-        self.cost_terms.append(weight * cs.sumsqr(self.joint_pos - self.joint_position_target))
+        self.cost_terms.append(
+            weight * cs.sumsqr(self.joint_pos - self.joint_position_target)
+        )
 
     def update_target_position(self, frame: str, position: np.ndarray):
         """Update the target position for a frame.
@@ -542,7 +544,11 @@ class InverseKinematics:
                 "Joint regularization has not been added. Call add_joint_regularization() first."
             )
         if joint_values is None:
-            joint_values = np.zeros(self.ndof) if self._cached_sol is None else self._cached_sol.value(self.joint_pos)
+            joint_values = (
+                np.zeros(self.ndof)
+                if self._cached_sol is None
+                else self._cached_sol.value(self.joint_pos)
+            )
             self.opti.set_value(self.joint_position_target, joint_values)
         else:
             self.opti.set_value(self.joint_position_target, joint_values)


### PR DESCRIPTION
This pull request adds support for joint regularization to the inverse kinematics module, allowing the cost function to penalize deviations from a desired joint configuration. The main changes introduce methods for adding and updating this regularization term.

**Inverse kinematics enhancements:**

* Added `add_joint_regularization` method to `InverseKinematics` for including a weighted regularization term in the cost function to minimize joint movement. (`src/adam/casadi/inverse_kinematics.py`)
* Added `update_joint_regularization` method to update the target joint values for the regularization term, with error handling if regularization hasn't been added yet. (`src/adam/casadi/inverse_kinematics.py`)

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--164.org.readthedocs.build/en/164/

<!-- readthedocs-preview adam-docs end -->